### PR TITLE
Expand BreadTalk brand listing to Asia and Europe

### DIFF
--- a/data/brands/shop/bakery.json
+++ b/data/brands/shop/bakery.json
@@ -417,7 +417,7 @@
     {
       "displayName": "BreadTalk",
       "id": "breadtalk-96a6b3",
-      "locationSet": {"include": ["sg"]},
+      "locationSet": {"include": ["142", "150"]},
       "tags": {
         "brand": "BreadTalk",
         "brand:wikidata": "Q1106640",


### PR DESCRIPTION
I think it's fair to show it to all OSM editors in these continents now.

> The Group has a network of owned bakery outlets in Singapore, PRC, Malaysia, Hong Kong and Thailand as well as franchised bakery outlets across Asia, Europe and the Middle East.